### PR TITLE
[UPM-1301] Remove passkey notification when user goes to desktop mode from mobile screen

### DIFF
--- a/packages/core/src/Stores/client-store.js
+++ b/packages/core/src/Stores/client-store.js
@@ -2713,12 +2713,16 @@ export default class ClientStore extends BaseStore {
     }
 
     async fetchShouldShowPasskeyNotification() {
-        try {
-            const data = await WS.authorized.send({ passkeys_list: 1 });
-            const should_show = data?.passkeys_list?.length === 0 && this.root_store.ui?.is_mobile;
-            this.setShouldShowPasskeyNotification(should_show);
-        } catch (e) {
-            //error handling needed
+        if (this.root_store.ui?.is_mobile) {
+            try {
+                const data = await WS.authorized.send({ passkeys_list: 1 });
+                const is_passkeys_empty = data?.passkeys_list?.length === 0;
+                this.setShouldShowPasskeyNotification(is_passkeys_empty);
+            } catch (e) {
+                //error handling needed
+            }
+        } else {
+            this.setShouldShowPasskeyNotification(false);
         }
     }
 

--- a/packages/core/src/Stores/client-store.js
+++ b/packages/core/src/Stores/client-store.js
@@ -456,12 +456,7 @@ export default class ClientStore extends BaseStore {
         reaction(
             () => [this.is_logged_in, this.is_authorize, this.is_passkey_supported, this.root_store.ui?.is_mobile],
             () => {
-                if (
-                    this.is_logged_in &&
-                    this.is_authorize &&
-                    this.is_passkey_supported &&
-                    this.root_store.ui?.is_mobile
-                ) {
+                if (this.is_logged_in && this.is_authorize && this.is_passkey_supported) {
                     this.fetchShouldShowPasskeyNotification();
                 }
             }
@@ -2720,9 +2715,8 @@ export default class ClientStore extends BaseStore {
     async fetchShouldShowPasskeyNotification() {
         try {
             const data = await WS.authorized.send({ passkeys_list: 1 });
-            if (data?.passkeys_list?.length === 0) {
-                this.setShouldShowPasskeyNotification(true);
-            }
+            const should_show = data?.passkeys_list?.length === 0 && this.root_store.ui?.is_mobile;
+            this.setShouldShowPasskeyNotification(should_show);
         } catch (e) {
             //error handling needed
         }

--- a/packages/core/src/Stores/notification-store.js
+++ b/packages/core/src/Stores/notification-store.js
@@ -119,6 +119,7 @@ export default class NotificationStore extends BaseStore {
                 root_store.client.is_eu,
                 root_store.client.has_enabled_two_fa,
                 root_store.client.has_changed_two_fa,
+                root_store.client.should_show_passkey_notification,
                 this.p2p_order_props.order_id,
             ],
             () => {
@@ -305,6 +306,7 @@ export default class NotificationStore extends BaseStore {
     }
 
     async handleClientNotifications() {
+        // console.log('handleClientNotifications called when is-mobile is ', this.root_store.ui?.is_mobile);
         const {
             account_settings,
             account_status,
@@ -353,6 +355,7 @@ export default class NotificationStore extends BaseStore {
         }
 
         if (is_logged_in) {
+            // console.log('should_show_passkey_notification', this.root_store.client.should_show_passkey_notification);
             if (isEmptyObject(account_status)) return;
             const {
                 authentication: { document, identity, income, needs_verification, ownership } = {},
@@ -411,6 +414,8 @@ export default class NotificationStore extends BaseStore {
 
             if (this.root_store.client.should_show_passkey_notification) {
                 this.addNotificationMessage(this.client_notifications.enable_passkey);
+            } else {
+                this.removeNotificationByKey({ key: this.client_notifications.enable_passkey });
             }
 
             const client = accounts[loginid];

--- a/packages/core/src/Stores/notification-store.js
+++ b/packages/core/src/Stores/notification-store.js
@@ -943,7 +943,7 @@ export default class NotificationStore extends BaseStore {
                     text: localize('Enable passkey'),
                 },
                 key: 'enable_passkey',
-                header: localize('Level up your security!'),
+                header: localize('Level up your security'),
                 message: localize('Strengthen your account’s security today with the latest passkeys feature.'),
                 type: 'announce',
                 should_show_again: true,

--- a/packages/core/src/Stores/notification-store.js
+++ b/packages/core/src/Stores/notification-store.js
@@ -306,7 +306,6 @@ export default class NotificationStore extends BaseStore {
     }
 
     async handleClientNotifications() {
-        // console.log('handleClientNotifications called when is-mobile is ', this.root_store.ui?.is_mobile);
         const {
             account_settings,
             account_status,
@@ -355,7 +354,6 @@ export default class NotificationStore extends BaseStore {
         }
 
         if (is_logged_in) {
-            // console.log('should_show_passkey_notification', this.root_store.client.should_show_passkey_notification);
             if (isEmptyObject(account_status)) return;
             const {
                 authentication: { document, identity, income, needs_verification, ownership } = {},


### PR DESCRIPTION
## Changes:

- removed the logic of checking `is_mobile` from reaction to `fetchShouldShowPasskeyNotification` function
- set the `should_show_passkey_notification` value based on the value of response and `is_mobile`
- added a trigger for `handleClientNotifications` whenever `should_show_passkey_notification` changes
- Modify the heading for notification, remove !
